### PR TITLE
Fixes the issue #18

### DIFF
--- a/share-site-creators-repo/src/main/amp/config/alfresco/module/share-site-creators-repo/context/bootstrap-context.xml
+++ b/share-site-creators-repo/src/main/amp/config/alfresco/module/share-site-creators-repo/context/bootstrap-context.xml
@@ -23,7 +23,7 @@
         <property name="description"><value>share-site-creators-repo.groupsLoader.description</value></property>
         <property name="fixesFromSchema"><value>0</value></property>
         <property name="fixesToSchema"><value>${version.schema}</value></property>
-        <property name="targetSchema"><value>10000</value></property>
+        <property name="targetSchema"><value>15000</value></property>
         <property name="importerBootstrap">
             <ref bean="spacesBootstrap" />
         </property>

--- a/share-site-creators-share/src/main/amp/config/alfresco/web-extension/site-data/site-creators-module-extension.xml
+++ b/share-site-creators-share/src/main/amp/config/alfresco/web-extension/site-data/site-creators-module-extension.xml
@@ -3,7 +3,7 @@
         <module>
             <id>Share Site Creators</id>
             <version>1.0</version>
-            <auto-deploy>false</auto-deploy>  
+            <auto-deploy>true</auto-deploy>
             <evaluator type="group.module.evaluator">
                 <params>
                     <groups>GROUP_SITE_CREATORS</groups>


### PR DESCRIPTION
I solved the problem setting the targetSchema to 15000.
The "default" value for targetSchema used to be 10000, but now that the Alfresco schema is already bigger than 10000, that value is no more useful.
By setting it to 15000 I was even able to install the addon into a 5.1.f.