### PR TITLE
Enable module to startup on an Alfresco 7.2 instance

### DIFF
--- a/share-site-creators-repo/src/main/resources/alfresco/module/share-site-creators-repo/context/bootstrap-context.xml
+++ b/share-site-creators-repo/src/main/resources/alfresco/module/share-site-creators-repo/context/bootstrap-context.xml
@@ -23,7 +23,7 @@
         <property name="description"><value>share-site-creators-repo.groupsLoader.description</value></property>
         <property name="fixesFromSchema"><value>0</value></property>
         <property name="fixesToSchema"><value>${version.schema}</value></property>
-        <property name="targetSchema"><value>15000</value></property>
+        <property name="targetSchema"><value>1000000</value></property>
         <property name="importerBootstrap">
             <ref bean="spacesBootstrap" />
         </property>


### PR DESCRIPTION
The current target schema version of the patch is lower than the current schema version of Alfresco 7.2 , so when this module is installed on Alfresco 7.2, Alfresco fails to startup.

Increasing the target schema version of the patch fixes the problem .